### PR TITLE
fix: Do not clear stats service on stoping the runnable

### DIFF
--- a/src/main/java/org/jitsi/stats/media/AbstractStatsPeriodicRunnable.java
+++ b/src/main/java/org/jitsi/stats/media/AbstractStatsPeriodicRunnable.java
@@ -272,8 +272,6 @@ public abstract class AbstractStatsPeriodicRunnable<T>
                 CallStatsConferenceEvents.CONFERENCE_TERMINATED,
                 userInfo);
         }
-
-        StatsServiceFactory.getInstance().stopStatsService(this.statsService.getId());
     }
 
     /**

--- a/src/main/java/org/jitsi/stats/media/StatsService.java
+++ b/src/main/java/org/jitsi/stats/media/StatsService.java
@@ -85,7 +85,7 @@ public class StatsService
      * Whether callstats was initialized.
      * @return whether callstats was initialized.
      */
-    boolean isInitialized()
+    public boolean isInitialized()
     {
         return initialized;
     }

--- a/src/main/java/org/jitsi/stats/media/StatsServiceFactory.java
+++ b/src/main/java/org/jitsi/stats/media/StatsServiceFactory.java
@@ -74,8 +74,9 @@ public class StatsServiceFactory
      * @param isClient The initiator will be reporting client connection (jigasi)
      * not server one (jvb).
      * @param callback  callback to be notified if callstats.io initialized orr failed to do so.
+     * @return returns the created service.
      */
-    public synchronized void createStatsService(
+    public synchronized StatsService createStatsService(
         final Version version,
         final int id,
         String appSecret,
@@ -86,7 +87,7 @@ public class StatsServiceFactory
         final InitCallback callback)
     {
         if (callStatsInstances.containsKey(id))
-            return;
+            return callStatsInstances.get(id);
 
          // prefer keyId/keyPath over appSecret
         if(keyId == null || keyPath == null)
@@ -98,7 +99,7 @@ public class StatsServiceFactory
                 callback.error("Missing parameres", "appSecret missing");
 
                 logger.warn("appSecret missing. Skipping callstats init");
-                return;
+                return null;
             }
         }
 
@@ -110,7 +111,8 @@ public class StatsServiceFactory
         // so it may be better to make the new CallStats instance available to
         // the rest of the statistics service before the method in question
         // returns even if it may fail.
-        callStatsInstances.put(id, new StatsService(id, callStats));
+        StatsService statsService = new StatsService(id, callStats);
+        callStatsInstances.put(id, statsService);
 
         CallStatsInitListener callStatsInitListener =
             new CallStatsInitListener()
@@ -172,6 +174,8 @@ public class StatsServiceFactory
                 serverInfo,
                 callStatsInitListener);
         }
+
+        return statsService;
     }
 
     /**


### PR DESCRIPTION
We need to have a single instance of Callstats for the lifetime of the component, do not clear it on stopping the reporting runnable.
We can still clean it with StatsServiceFactory.getInstance().stopStatsService.